### PR TITLE
Fixed javax.xml dependency in modern Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 					<descriptors>
 						<descriptor>src/assembly/distribution.xml</descriptor>
 					</descriptors>
+					<tarLongFileMode>posix</tarLongFileMode>
 				</configuration>
 				<executions>
 					<execution>
@@ -103,6 +104,11 @@
 			<groupId>net.fusejna</groupId>
 			<artifactId>fuse-jna</artifactId>
 			<version>1.0.3</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added dependency on now external jaxb libraries. 
Added tag to package tar on Mac OS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
